### PR TITLE
modified syntax of 02_tidytree.Rmd

### DIFF
--- a/02_tidytree.Rmd
+++ b/02_tidytree.Rmd
@@ -119,7 +119,7 @@ All these methods are also implemented in `r Biocpkg("treeio")` for working with
 child(tree, 5)
 ```
 
-Beware that the methods work for tree objects output related node numbers, while the methods implemented for the `tbl_tree` object output a `tibble` object that contains related information.
+Beware that the methods for tree objects output relevant node numbers, while the methods for `tbl_tree` object output a `tibble` object that contains related information.
 
 
 ## Data Integration
@@ -198,7 +198,7 @@ The output is illustrated in Fig. \@ref(fig:correlations). We can then test the 
 
 Using the `merge_tree()` function, we are able to compare analysis results using an identical
 model from different software packages or different models using different or
-identical software. It also allows users to integrate different analysis finding
+identical software. It also allows users to integrate different analysis findings
 from different software packages. Merging tree data is not restricted to
 software findings, associating external data to analysis findings is also
 granted. The `merge_tree()` function is chainable and allows several tree objects
@@ -229,10 +229,10 @@ above, there is a wide range of heterogeneous data, including phenotypic data,
 experimental data, and clinical data, *etc.*, that need to be integrated and
 linked to phylogeny. For example, in the study of viral evolution, tree nodes may be
 associated with epidemiological information, such as location, age, and subtype.
-Functional annotations may need to be mapped on gene trees for comparative
+Functional annotations may need to be mapped onto gene trees for comparative
 genomics studies. To facilitate data
 integration, `r Biocpkg("treeio")` provides
-`full_join()` method to link external data to phylogeny and store it in either `phylo` or `treedata` object. Beware that linking external data to a `phylo` object will produce a `treedata` object to store the input `phylo` with associated data. The `full_join` methods can also be used at tidy data frame level (*i.e.* `tbl_tree` object described previously) and at `ggtree` level (described in [Chapter 7](#attach-operator)) [@yu_two_2018].
+`full_join()` method to link external data to phylogeny and store it in either `phylo` or `treedata` object. Beware that linking external data to a `phylo` object will produce a `treedata` object to store the input `phylo` with associated data. The `full_join` method can also be used at tidy data frame level (*i.e.* `tbl_tree` object described previously) and at `ggtree` level (described in [Chapter 7](#attach-operator)) [@yu_two_2018].
 
 
 The following example calculated bootstrap values and merged that values with the tree (a `phylo` object) by matching their node numbers.
@@ -542,7 +542,7 @@ If you are interested in a certain clade, you can specify the input node as an i
 
 (ref:subsetNodescap) Subsetting tree for a specific clade.
 
-(ref:ssubsetNodecap) **Subsetting tree for the specific clade.** Extracting a clade (A). Extract a clade and trace it back to look at its immediate relatives (B). Viewing a very large tree (C) and a selected portion of it (D).
+(ref:ssubsetNodecap) **Subsetting tree for the specific clade.** Extracting a clade (A). Extracting a clade and tracing it back to look at its immediate relatives (B). Viewing a very large tree (C) and a selected portion of it (D).
 
 ```{r subsetNode, fig.width=10, fig.height=10, echo=T, fig.cap="(ref:ssubsetNodecap)", fig.scap="(ref:subsetNodescap)", out.extra='', out.width="100%"}
 clade <- tree_subset(beast_tree, node=121, levels_back=0)
@@ -656,5 +656,5 @@ p1 + geom_tree(data = d2) + geom_tree(data = d3) + geom_tiplab(data=d3) +
 
 ## Summary {#summary2}
 
-The `r Biocpkg("treeio")` package allows us to import diverse phylogeny associated data into R. However, a phylogenetic tree is stored in a way to facilitate computational processing which is not human friendly and needs the expertise to manipulate and explore tree data. The `r CRANpkg("tidytree")` package provides a tidy interface for exploring tree data, while `r Biocpkg("ggtree")` provides a set of utilities to visualize and explore tree data using the grammar of graphics. This full suite of packages makes it easy for ordinary users to interact with tree data and allow us to integrate phylogeny associated data from different sources (*e.g.* experimental result or analysis finding), which creates the possibilities of integrative and comparative study. Moreover, this package suite brings phylogenetic analysis into the tidyverse and certainly takes us to the next level of processing phylogenetic data.
+The `r Biocpkg("treeio")` package allows us to import diverse phylogeny associated data into R. However, a phylogenetic tree is stored in a way to facilitate computational processing which is not human friendly and needs the expertise to manipulate and explore tree data. The `r CRANpkg("tidytree")` package provides a tidy interface for exploring tree data, while `r Biocpkg("ggtree")` provides a set of utilities to visualize and explore tree data using the grammar of graphics. This full suite of packages makes it easy for ordinary users to interact with tree data and allows us to integrate phylogeny associated data from different sources (*e.g.* experimental results or analysis findings), which creates the possibilities of integrative and comparative study. Moreover, this package suite brings phylogenetic analysis into the tidyverse and certainly takes us to the next level of processing phylogenetic data.
 


### PR DESCRIPTION
6 changes:

1. line 122: too complex;
2. line 201: replaced 'different analysis finding' to 'different analysis findings' ;
3. line 232: replaced 'be mapped on' to 'be mapped onto';
4. line 235: replaced 'The `full_join` methods' to 'The `full_join` method';
5. line 545: 'Extract' to 'Extracting', 'trace' to 'tracing';
6. line 659:  'allow' to 'allows', 'result' to 'results', 'finding' to 'findings'.